### PR TITLE
Add config to remove root ssh access and install fail2ban

### DIFF
--- a/user-data.yaml
+++ b/user-data.yaml
@@ -13,3 +13,4 @@ users:
       - gh:deetergp
       - gh:objectsforheads
       - gh:qpfiffer
+disable_root: true

--- a/user-data.yaml
+++ b/user-data.yaml
@@ -14,3 +14,6 @@ users:
       - gh:objectsforheads
       - gh:qpfiffer
 disable_root: true
+package_update: true
+packages:
+  - fail2ban


### PR DESCRIPTION
## Resolves
https://github.com/learntouselinux/learntouselinux/issues/30
https://github.com/learntouselinux/learntouselinux/issues/31

I wanted to solve https://github.com/learntouselinux/learntouselinux/issues/32 in this PR as well but it looked more complicated than what are essentially 2 one-liners. I can call this a PR a WIP and add that on but this can be merged as-is as well.

## Tests

1. Confirm that root cannot ssh in:
```
$ ssh root@138.68.44.28
root@138.68.44.28: Permission denied (publickey).
```

2. Confirm that fail2ban has been added:
```
$ sudo fail2ban-client version
0.10.2
```

## Resources
https://cloudinit.readthedocs.io/en/latest/topics/modules.html#ssh
https://cloudinit.readthedocs.io/en/latest/topics/modules.html#package-update-upgrade-install
https://www.fail2ban.org/wiki/index.php/Commands

And the issues themselves are great founts of information as well. Great job there jerry 👏 