### PR TITLE
Apache setup, app index file setup, terraform adjustments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 provider "digitalocean" {}
 
-resource "digitalocean_droplet" "droplet" {
+resource "digitalocean_droplet" "droplets" {
   count = "${var.droplet_count}"
   image = "${var.image}"
   name = "${var.name}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,5 @@
 output "droplet_ip" {
+  # NOTE: the for loop syntax is not backwards compatible with terraform <0.12.x.
   value = {
     for index, droplet in digitalocean_droplet.droplets:
     index => droplet.ipv4_address

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
 output "droplet_ip" {
-  value = "${digitalocean_droplet.droplet[0].ipv4_address}"
+  value = {
+    for index, droplet in digitalocean_droplet.droplets:
+    index => droplet.ipv4_address
+  }
+  # A list of ips can also be created using tf splat operator
+  # value = digitalocean_droplet.droplets.*.ipv4_address
 }

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,19 +1,26 @@
 {
   "version": 4,
   "terraform_version": "0.12.10",
-  "serial": 2,
+  "serial": 5,
   "lineage": "143cc2ec-77f3-cdab-0e2e-f6b1291687f9",
   "outputs": {
     "droplet_ip": {
-      "value": "138.68.44.28",
-      "type": "string"
+      "value": {
+        "0": "157.245.169.240"
+      },
+      "type": [
+        "object",
+        {
+          "0": "string"
+        }
+      ]
     }
   },
   "resources": [
     {
       "mode": "managed",
       "type": "digitalocean_droplet",
-      "name": "droplet",
+      "name": "droplets",
       "each": "list",
       "provider": "provider.digitalocean",
       "instances": [
@@ -22,11 +29,11 @@
           "schema_version": 1,
           "attributes": {
             "backups": false,
-            "created_at": "2019-10-18T03:03:31Z",
+            "created_at": "2019-11-06T04:09:16Z",
             "disk": 25,
-            "id": "163394563",
+            "id": "165772937",
             "image": "ubuntu-18-04-x64",
-            "ipv4_address": "138.68.44.28",
+            "ipv4_address": "157.245.169.240",
             "ipv4_address_private": "",
             "ipv6": false,
             "ipv6_address": "",
@@ -46,8 +53,8 @@
             ],
             "status": "active",
             "tags": null,
-            "urn": "do:droplet:163394563",
-            "user_data": "5f01c52d171557eef9fbaca2a463e3d187167fa6",
+            "urn": "do:droplet:165772937",
+            "user_data": "e13393b243af9078a688798187ae7c4d7e021839",
             "vcpus": 1,
             "volume_ids": []
           },

--- a/user-data.yaml
+++ b/user-data.yaml
@@ -1,4 +1,5 @@
 #cloud-config
+# Create single user (ltul) with all team members SSH keys added to authorized keys.
 users:
   - name: ltul
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
@@ -14,11 +15,14 @@ users:
       - gh:toozej
       - gh:yevgenybulochnik
 
+# Update apt package cache.
 package_update: true
 
+# Install Apache
 packages:
   - apache2
 
+# Write virtual host file to Apache sites-available.
 write_files:
   - path: /etc/apache2/sites-available/learntouselinux.com.conf
     content: |
@@ -27,14 +31,24 @@ write_files:
           DocumentRoot /var/www/learntouselinux.com
       </Virtualhost>
 
+# Commands to setup apache and serve app indext.html
 runcmd:
+  # Disabled default sites and removed default virtual hosts.
   - a2dissite 000-default.conf
   - rm /etc/apache2/sites-available/000-default.conf
   - rm /etc/apache2/sites-available/default-ssl.conf
+  # Removing Apache default documentroot and create learntouselinux.com
   - rm -rf /var/www/html
   - mkdir /var/www/learntouselinux.com
+  # Enabling learntouselinux.com.conf
   - a2ensite learntouselinux.com.conf
-  - git clone https://github.com/learntouselinux/app /tmp/app
-  - cp /tmp/app/index.html /var/www/learntouselinux.com
+  # Clone app repo to ltul ~
+  - git clone https://github.com/learntouselinux/app /home/ltul/app
+  # Change ownership of app repo from root to ltul
+  - chown -R ltul:ltul /home/ltul/app
+  # Symlink index.html file to learntouselinux.com
+  - ln -snf /home/ltul/app/index.html /var/www/learntouselinux.com
+  # Change ownership of learntouselinux.com from root to Apache(www-data)
   - chown -R www-data:www-data /var/www/learntouselinux.com
+  # Reloading Apache2
   - systemctl reload apache2

--- a/user-data.yaml
+++ b/user-data.yaml
@@ -1,5 +1,5 @@
 #cloud-config
-# Create single user (ltul) with all team members SSH keys added to authorized keys.
+# Create single user (ltul) with all team members SSH keys added to authorized keys
 users:
   - name: ltul
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
@@ -15,14 +15,14 @@ users:
       - gh:toozej
       - gh:yevgenybulochnik
 
-# Update apt package cache.
+# Update apt package cache
 package_update: true
 
 # Install Apache
 packages:
   - apache2
 
-# Write virtual host file to Apache sites-available.
+# Write virtual host file to Apache sites-available
 write_files:
   - path: /etc/apache2/sites-available/learntouselinux.com.conf
     content: |
@@ -33,7 +33,7 @@ write_files:
 
 # Commands to setup apache and serve app indext.html
 runcmd:
-  # Disabled default sites and removed default virtual hosts.
+  # Disabled default sites and removed default virtual hosts
   - a2dissite 000-default.conf
   - rm /etc/apache2/sites-available/000-default.conf
   - rm /etc/apache2/sites-available/default-ssl.conf

--- a/user-data.yaml
+++ b/user-data.yaml
@@ -4,12 +4,37 @@ users:
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
     shell: /bin/bash
     ssh_import_id:
-      - gh:yevgenybulochnik
       - gh:bri997
+      - gh:deetergp
       - gh:jerrywardlow
+      - gh:objectsforheads
+      - gh:qpfiffer
       - gh:sanchezricky
       - gh:swhi3635
       - gh:toozej
-      - gh:deetergp
-      - gh:objectsforheads
-      - gh:qpfiffer
+      - gh:yevgenybulochnik
+
+package_update: true
+
+packages:
+  - apache2
+
+write_files:
+  - path: /etc/apache2/sites-available/learntouselinux.com.conf
+    content: |
+      <Virtualhost *:80>
+          Servername learntouselinux.com
+          DocumentRoot /var/www/learntouselinux.com
+      </Virtualhost>
+
+runcmd:
+  - a2dissite 000-default.conf
+  - rm /etc/apache2/sites-available/000-default.conf
+  - rm /etc/apache2/sites-available/default-ssl.conf
+  - rm -rf /var/www/html
+  - mkdir /var/www/learntouselinux.com
+  - a2ensite learntouselinux.com.conf
+  - git clone https://github.com/learntouselinux/app /tmp/app
+  - cp /tmp/app/index.html /var/www/learntouselinux.com
+  - chown -R www-data:www-data /var/www/learntouselinux.com
+  - systemctl reload apache2


### PR DESCRIPTION
Apologize in advance, this PR addresses multiple issues. It just made more sense for me to make some of these changes in the same PR. 
1. Alphabetized github ssh key imports
2. Adjusted `droplet_ip` output to give a key value mapping based on droplet index => ip4v_address
3. Install and configure apache2
4. use `git` to clone the app repo into `/tmp` and `cp` the index file into `/var/www/learntouselinux.com` 

NOTE: At this time I have not committed changes to `terraform.tfstate` once this PR is ready to merge I will create another commit for the new tfstate and create a PR to adjust the dns records 

## Resolves
learntouselinux/learntouselinux#25 
learntouselinux/learntouselinux#26 
learntouselinux/learntouselinux#32 
learntouselinux/learntouselinux#33 

## Tests
Droplet output
```
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

droplet_ip = {
  "0" = "167.71.144.138"
}
```
Result of `curl 167.71.144.138`
```
Delete all other operating systems.
```