### PR TITLE
Disable root login in user-data

### DIFF
--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,12 +1,12 @@
 {
   "version": 4,
-  "terraform_version": "0.12.10",
-  "serial": 5,
+  "terraform_version": "0.12.13",
+  "serial": 8,
   "lineage": "143cc2ec-77f3-cdab-0e2e-f6b1291687f9",
   "outputs": {
     "droplet_ip": {
       "value": {
-        "0": "157.245.169.240"
+        "0": "167.172.200.126"
       },
       "type": [
         "object",
@@ -29,11 +29,11 @@
           "schema_version": 1,
           "attributes": {
             "backups": false,
-            "created_at": "2019-11-06T04:09:16Z",
+            "created_at": "2019-11-13T17:58:37Z",
             "disk": 25,
-            "id": "165772937",
+            "id": "166913594",
             "image": "ubuntu-18-04-x64",
-            "ipv4_address": "157.245.169.240",
+            "ipv4_address": "167.172.200.126",
             "ipv4_address_private": "",
             "ipv6": false,
             "ipv6_address": "",
@@ -53,8 +53,8 @@
             ],
             "status": "active",
             "tags": null,
-            "urn": "do:droplet:165772937",
-            "user_data": "e13393b243af9078a688798187ae7c4d7e021839",
+            "urn": "do:droplet:166913594",
+            "user_data": "4d25a0858bda37936d52222f807d35189d5970c1",
             "vcpus": 1,
             "volume_ids": []
           },

--- a/user-data.yaml
+++ b/user-data.yaml
@@ -33,6 +33,8 @@ write_files:
 
 # Commands to setup apache and serve app indext.html
 runcmd:
+  # Remove authorized SSH keys from 'root' user
+  - rm -f /root/.ssh/authorized_keys
   # Disabled default sites and removed default virtual hosts
   - a2dissite 000-default.conf
   - rm /etc/apache2/sites-available/000-default.conf

--- a/user-data.yaml
+++ b/user-data.yaml
@@ -35,6 +35,8 @@ write_files:
 runcmd:
   # Remove authorized SSH keys from 'root' user
   - rm -f /root/.ssh/authorized_keys
+  # Modify sshd config to forbid 'root' login
+  - sed 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config
   # Disabled default sites and removed default virtual hosts
   - a2dissite 000-default.conf
   - rm /etc/apache2/sites-available/000-default.conf


### PR DESCRIPTION
Fixes learntouselinux/learntouselinux#30

## Explanation
Updated `user-data` file to disable 'root' user login via modification of SSH Daemon config `/etc/ssh/sshd_config` and removal of 'authorized_keys' file.

## Rationale
Disabling root access is considered good security practice.

## Tests
1. What testing did you do?
Ran commands manually in a VM
1. Attach testing logs inside a summary block:

<details>
<summary>testing logs</summary>

```
$ grep "PermitRootLogin yes" /etc/ssh/sshd_config 
PermitRootLogin yes
$ sed 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config
$ grep "PermitRootLogin yes" /etc/ssh/sshd_config
$
```
```
$ ls -al /root/.ssh/authorized_keys
-rw------- 1 root root 395 Nov  6 04:10 /root/.ssh/authorized_keys
$ rm -f /root/.ssh/authorized_keys
$ ls -al /root/.ssh/authorized_keys
$
```

```
horacio 09:57:55 ~/src/github/learntouselinux/infra $> terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

digitalocean_droplet.droplets[0]: Refreshing state... [id=165772937]

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # digitalocean_droplet.droplets[0] must be replaced
-/+ resource "digitalocean_droplet" "droplets" {
        backups              = false
      ~ created_at           = "2019-11-06T04:09:16Z" -> (known after apply)
      ~ disk                 = 25 -> (known after apply)
      ~ id                   = "165772937" -> (known after apply)
        image                = "ubuntu-18-04-x64"
      ~ ipv4_address         = "157.245.169.240" -> (known after apply)
      + ipv4_address_private = (known after apply)
        ipv6                 = false
      + ipv6_address         = (known after apply)
      + ipv6_address_private = (known after apply)
      ~ locked               = false -> (known after apply)
      ~ memory               = 1024 -> (known after apply)
        monitoring           = false
        name                 = "ltul"
      ~ price_hourly         = 0.00744 -> (known after apply)
      ~ price_monthly        = 5 -> (known after apply)
        private_networking   = false
        region               = "sfo2"
        resize_disk          = true
        size                 = "s-1vcpu-1gb"
        ssh_keys             = [
            "66:0b:e5:21:cb:ce:c1:ae:f7:f0:16:d2:98:cc:bc:3d",
        ]
      ~ status               = "active" -> (known after apply)
      - tags                 = [] -> null
      ~ urn                  = "do:droplet:165772937" -> (known after apply)
      ~ user_data            = "e13393b243af9078a688798187ae7c4d7e021839" -> "4d25a0858bda37936d52222f807d35189d5970c1" # forces replacement
      ~ vcpus                = 1 -> (known after apply)
      ~ volume_ids           = [] -> (known after apply)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.

horacio 09:57:58 ~/src/github/learntouselinux/infra $> terraform apply
digitalocean_droplet.droplets[0]: Refreshing state... [id=165772937]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # digitalocean_droplet.droplets[0] must be replaced
-/+ resource "digitalocean_droplet" "droplets" {
        backups              = false
      ~ created_at           = "2019-11-06T04:09:16Z" -> (known after apply)
      ~ disk                 = 25 -> (known after apply)
      ~ id                   = "165772937" -> (known after apply)
        image                = "ubuntu-18-04-x64"
      ~ ipv4_address         = "157.245.169.240" -> (known after apply)
      + ipv4_address_private = (known after apply)
        ipv6                 = false
      + ipv6_address         = (known after apply)
      + ipv6_address_private = (known after apply)
      ~ locked               = false -> (known after apply)
      ~ memory               = 1024 -> (known after apply)
        monitoring           = false
        name                 = "ltul"
      ~ price_hourly         = 0.00744 -> (known after apply)
      ~ price_monthly        = 5 -> (known after apply)
        private_networking   = false
        region               = "sfo2"
        resize_disk          = true
        size                 = "s-1vcpu-1gb"
        ssh_keys             = [
            "66:0b:e5:21:cb:ce:c1:ae:f7:f0:16:d2:98:cc:bc:3d",
        ]
      ~ status               = "active" -> (known after apply)
      - tags                 = [] -> null
      ~ urn                  = "do:droplet:165772937" -> (known after apply)
      ~ user_data            = "e13393b243af9078a688798187ae7c4d7e021839" -> "4d25a0858bda37936d52222f807d35189d5970c1" # forces replacement
      ~ vcpus                = 1 -> (known after apply)
      ~ volume_ids           = [] -> (known after apply)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

digitalocean_droplet.droplets[0]: Destroying... [id=165772937]
digitalocean_droplet.droplets[0]: Still destroying... [id=165772937, 10s elapsed]
digitalocean_droplet.droplets[0]: Still destroying... [id=165772937, 20s elapsed]
digitalocean_droplet.droplets[0]: Destruction complete after 23s
digitalocean_droplet.droplets[0]: Creating...
digitalocean_droplet.droplets[0]: Still creating... [10s elapsed]
digitalocean_droplet.droplets[0]: Still creating... [20s elapsed]
digitalocean_droplet.droplets[0]: Still creating... [30s elapsed]
digitalocean_droplet.droplets[0]: Still creating... [40s elapsed]
digitalocean_droplet.droplets[0]: Creation complete after 45s [id=166913594]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.

Outputs:

droplet_ip = {
  "0" = "167.172.200.126"
}
```
</details>

