### PR TITLE
[HOLD] Add fail2ban package

### DIFF
--- a/user-data.yaml
+++ b/user-data.yaml
@@ -21,6 +21,7 @@ package_update: true
 # Install Apache
 packages:
   - apache2
+  - fail2ban
 
 # Write virtual host file to Apache sites-available
 write_files:


### PR DESCRIPTION
Fixes learntouselinux/learntouselinux#31

## Explanation
Adds fail2ban package.

## Rationale
Discussed in aforementioned issue

## Tests
1. What testing did you do? 
N/A
1. Attach testing logs inside a summary block:

<details>
<summary>testing logs</summary>

```
N/A
```
</details>

